### PR TITLE
Implement early stopping

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -527,10 +527,10 @@ valid-metaclass-classmethod-first-arg=cls
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=15
+max-args=20
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=15
+max-attributes=20
 
 # Maximum number of boolean expressions in an if statement.
 max-bool-expr=5
@@ -539,7 +539,7 @@ max-bool-expr=5
 max-branches=12
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=20
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/evopy/evopy.py
+++ b/evopy/evopy.py
@@ -11,7 +11,7 @@ from evopy.utils import random_with_seed
 
 class EvoPy:
     """Main class of the EvoPy package."""
-    # pylint: disable=R0914
+
     def __init__(self, fitness_function, individual_length, warm_start=None, generations=100,
                  population_size=30, num_children=1, mean=0, std=1, maximize=False,
                  strategy=Strategy.SINGLE_VARIANCE, random_seed=None, reporter=None,
@@ -51,13 +51,17 @@ class EvoPy:
         self.max_run_time = max_run_time
 
     def _check_early_stop(self, start_time, best):
-        """Utility method for early stopping
-        """
-        return (self.max_run_time is not None and \
-            (time.time() - start_time) > self.max_run_time) \
-        or (self.target_fitness_value is not None and \
-            abs(best.fitness - self.target_fitness_value) < np.finfo(float).eps)
+        """Check whether the algorithm can stop early, based on time and fitness target.
 
+        :param start_time: the starting time to compare against
+        :param best: the current best individual
+        :return: whether the algorithm should be terminated early
+        """
+        return (self.max_run_time is not None
+                and (time.time() - start_time) > self.max_run_time) \
+               or \
+               (self.target_fitness_value is not None
+                and abs(best.fitness - self.target_fitness_value) < np.finfo(float).eps)
 
     def run(self):
         """Run the evolutionary strategy algorithm.
@@ -86,6 +90,7 @@ class EvoPy:
 
             if self._check_early_stop(start_time, best):
                 break
+
         return best.genotype
 
     def _init_population(self):

--- a/evopy/evopy.py
+++ b/evopy/evopy.py
@@ -1,4 +1,6 @@
 """Module used for the execution of the evolutionary algorithm."""
+import time
+
 import numpy as np
 
 from evopy.individual import Individual
@@ -9,10 +11,11 @@ from evopy.utils import random_with_seed
 
 class EvoPy:
     """Main class of the EvoPy package."""
-
+    # pylint: disable=R0914
     def __init__(self, fitness_function, individual_length, warm_start=None, generations=100,
                  population_size=30, num_children=1, mean=0, std=1, maximize=False,
-                 strategy=Strategy.SINGLE_VARIANCE, random_seed=None, reporter=None):
+                 strategy=Strategy.SINGLE_VARIANCE, random_seed=None, reporter=None,
+                 target_fitness_value=None, max_run_time=None):
         """Initializes an EvoPy instance.
 
         :param fitness_function: the fitness function on which the individuals are evaluated
@@ -28,6 +31,8 @@ class EvoPy:
                          information, check the Strategy enum
         :param random_seed: the seed to use for the random number generator
         :param reporter: callback to be invoked at each generation with a ProgressReport as argument
+        :param target_fitness_value: target fitness value for early stopping
+        :param max_run_time: maximum time allowed to run in seconds
         """
         self.fitness_function = fitness_function
         self.individual_length = individual_length
@@ -42,6 +47,17 @@ class EvoPy:
         self.random_seed = random_seed
         self.random = random_with_seed(self.random_seed)
         self.reporter = reporter
+        self.target_fitness_value = target_fitness_value
+        self.max_run_time = max_run_time
+
+    def _check_early_stop(self, start_time, best):
+        """Utility method for early stopping
+        """
+        return (self.max_run_time is not None and \
+            (time.time() - start_time) > self.max_run_time) \
+        or (self.target_fitness_value is not None and \
+            abs(best.fitness - self.target_fitness_value) < np.finfo(float).eps)
+
 
     def run(self):
         """Run the evolutionary strategy algorithm.
@@ -50,6 +66,8 @@ class EvoPy:
         """
         if self.individual_length == 0:
             return None
+
+        start_time = time.time()
 
         population = self._init_population()
         best = sorted(population, reverse=self.maximize,
@@ -62,9 +80,12 @@ class EvoPy:
                                 key=lambda individual: individual.evaluate(self.fitness_function))
             population = population[:self.population_size]
             best = population[0]
+
             if self.reporter is not None:
                 self.reporter(ProgressReport(generation, best.genotype, best.fitness))
 
+            if self._check_early_stop(start_time, best):
+                break
         return best.genotype
 
     def _init_population(self):

--- a/test/test_evopy.py
+++ b/test/test_evopy.py
@@ -3,11 +3,13 @@ import numpy as np
 
 from evopy import EvoPy
 
+
 def test_random_consistency():
     """Test whether the random state gives consistent runs when initialized."""
     x_first = EvoPy(lambda x: pow(x, 2), 1, random_seed=42).run()
     x_second = EvoPy(lambda x: pow(x, 2), 1, random_seed=42).run()
     assert x_first == x_second
+
 
 def test_random_consistency_multiple_runs():
     """"Test whether the random state is not re-used in sequential runs"""
@@ -15,6 +17,7 @@ def test_random_consistency_multiple_runs():
     x_first = evopy.run()
     x_second = evopy.run()
     assert x_first != x_second
+
 
 def test_simple_use_case():
     """Test whether evopy can successfully run for a simple evaluation function."""
@@ -24,8 +27,9 @@ def test_simple_use_case():
     assert isinstance(best_individual, np.ndarray)
     assert best_individual.size == 1
 
+
 def test_early_timed_stop():
-    """Test whether evopy can successfully stop early when given a time constraint."""
+    """Test whether evopy can successfully stop early when given a specified time constraint."""
     count = [0]
 
     def increment_reporter(report):
@@ -36,8 +40,9 @@ def test_early_timed_stop():
 
     assert count[0] == 1
 
+
 def test_early_target_value_stop():
-    """Test whether evopy can successfully stop after achieving target value."""
+    """Test whether evopy can successfully stop after achieving a specified target value."""
     count = [0]
 
     def increment_reporter(report):
@@ -47,6 +52,7 @@ def test_early_target_value_stop():
     evopy.run()
 
     assert count[0] == 1
+
 
 def test_empty_input_array():
     """Test whether evopy can successfully run for a simple evaluation function."""

--- a/test/test_evopy.py
+++ b/test/test_evopy.py
@@ -24,6 +24,29 @@ def test_simple_use_case():
     assert isinstance(best_individual, np.ndarray)
     assert best_individual.size == 1
 
+def test_early_timed_stop():
+    """Test whether evopy can successfully stop early when given a time constraint."""
+    count = [0]
+
+    def increment_reporter(report):
+        count[0] = report.generation + 1
+
+    evopy = EvoPy(lambda x: pow(x, 2), 1, max_run_time=0, reporter=increment_reporter)
+    evopy.run()
+
+    assert count[0] == 1
+
+def test_early_target_value_stop():
+    """Test whether evopy can successfully stop after achieving target value."""
+    count = [0]
+
+    def increment_reporter(report):
+        count[0] = report.generation + 1
+
+    evopy = EvoPy(lambda x: 0, 1, target_fitness_value=0, reporter=increment_reporter)
+    evopy.run()
+
+    assert count[0] == 1
 
 def test_empty_input_array():
     """Test whether evopy can successfully run for a simple evaluation function."""


### PR DESCRIPTION
Fixes #6 #4

Implements early stopping through `_check_early_stop` in `evopy.py`.

I think it might be useful to create an issue (I can do so if we can agree on how important this feature could be) on returning a 'history' of `evopy.run`. It would make writing tests a bit earlier.